### PR TITLE
Modify path where .env file is created 

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,12 +24,22 @@ react_node_version: 10.x
 # app
 react_remote_js_build: true
 react_local_checkout_path: "/tmp/{{ react_local_user }}/reveal"
+react_local_app_path: "{{ react_local_checkout_path }}"
+react_local_npm_package_paths:
+  - "{{react_local_checkout_path}}"
+  - "{{react_local_app_path}}"
 react_env_name: "prod"
 react_app_name: "{{ react_system_user }}"
 react_codebase_path: "{{ react_system_user_home }}/app"
 react_versioned_path: "{{ react_codebase_path }}-versioned"
+# where the repository is cloned
 react_checkout_path: "{{ react_versioned_path }}/{{ ansible_date_time['epoch'] }}"
+# where the actual app package is
 react_app_path: "{{ react_checkout_path }}"
+# packages whose npms dependencies need to be installed
+react_npm_package_paths:
+  - "{{react_checkout_path}}"
+  - "{{react_app_path}}"
 react_log_path: "/var/log/{{ react_app_name }}"
 react_max_versioned_folders: 10
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,9 +25,6 @@ react_node_version: 10.x
 react_remote_js_build: true
 react_local_checkout_path: "/tmp/react/{{ ansible_date_time['epoch'] }}"
 react_local_app_path: "{{ react_local_checkout_path }}"
-react_local_npm_package_paths:
-  - "{{react_local_checkout_path}}"
-  - "{{react_local_app_path}}"
 react_env_name: "prod"
 react_app_name: "{{ react_system_user }}"
 react_codebase_path: "{{ react_system_user_home }}/app"
@@ -37,9 +34,6 @@ react_checkout_path: "{{ react_versioned_path }}/{{ ansible_date_time['epoch'] }
 # where the actual app package is
 react_app_path: "{{ react_checkout_path }}"
 # packages whose npms dependencies need to be installed
-react_npm_package_paths:
-  - "{{react_checkout_path}}"
-  - "{{react_app_path}}"
 react_log_path: "/var/log/{{ react_app_name }}"
 react_max_versioned_folders: 10
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -33,7 +33,6 @@ react_versioned_path: "{{ react_codebase_path }}-versioned"
 react_checkout_path: "{{ react_versioned_path }}/{{ ansible_date_time['epoch'] }}"
 # where the actual app package is
 react_app_path: "{{ react_checkout_path }}"
-# packages whose npms dependencies need to be installed
 react_log_path: "/var/log/{{ react_app_name }}"
 react_max_versioned_folders: 10
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,7 +23,7 @@ react_node_version: 10.x
 
 # app
 react_remote_js_build: true
-react_local_checkout_path: "/tmp/{{ react_local_user }}/reveal"
+react_local_checkout_path: "/tmp/react/{{ ansible_date_time['epoch'] }}"
 react_local_app_path: "{{ react_local_checkout_path }}"
 react_local_npm_package_paths:
   - "{{react_local_checkout_path}}"

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -8,9 +8,11 @@
         react_system_group: "www-data"
         react_system_user_home: "/home/{{ react_system_user }}"
         react_node_version: 10.x
-        react_git_url: "https://github.com/onaio/reveal-frontend"
-        react_git_version: "v0.6.2-rc1"
+        react_git_url: "https://github.com/OpenSRP/web.git"
+        react_git_version: "master"
         react_app_settings:
-          GENERATE_SOURCEMAP: "false"
+          GENERATE_SOUreact_local_checkout_pathRCEMAP: "false"
           SKIP_PREFLIGHT_CHECK: "true"
-        react_remote_js_build: false
+        react_remote_js_build: False
+        react_local_app_path: "{{ react_local_checkout_path }}/client"
+        react_app_path: "{{ react_checkout_path }}/client"

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -11,7 +11,7 @@
         react_git_url: "https://github.com/OpenSRP/web.git"
         react_git_version: "master"
         react_app_settings:
-          GENERATE_SOUreact_local_checkout_pathRCEMAP: "false"
+          GENERATE_SOURCEMAP: "false"
           SKIP_PREFLIGHT_CHECK: "true"
         react_remote_js_build: false
         react_local_app_path: "{{ react_local_checkout_path }}/client"

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -13,6 +13,6 @@
         react_app_settings:
           GENERATE_SOUreact_local_checkout_pathRCEMAP: "false"
           SKIP_PREFLIGHT_CHECK: "true"
-        react_remote_js_build: False
+        react_remote_js_build: false
         react_local_app_path: "{{ react_local_checkout_path }}/client"
         react_app_path: "{{ react_checkout_path }}/client"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -28,13 +28,24 @@
       become_user: "{{ react_local_user }}"
 
     - name: Remove node_modules before compression
-      file:
-        path: "{{ item }}/node_modules"
-        state: absent
-      delegate_to: localhost
-      become: true
-      become_user: "{{ react_local_user }}"
-      loop: "{{react_local_npm_package_paths}}"
+      block:
+        - name: Remove node_modules using lerna where possible
+          command: yarn lerna clean -y
+          args:
+            chdir: "{{ react_local_checkout_path }}"
+          ignore_errors: true
+          delegate_to: localhost
+          become: true
+          become_user: "{{ react_local_user }}"
+
+        - name: remove node_modules manually
+          file:
+            path: "{{ item }}/node_modules"
+            state: absent
+          delegate_to: localhost
+          become: true
+          become_user: "{{ react_local_user }}"
+          loop: "{{react_local_npm_package_paths}}"
 
     - name: Compress Build folder locally
       archive:

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -4,7 +4,7 @@
     - name: Copy environment variables file locally
       template:
         src: env.j2
-        dest: "{{ react_local_checkout_path }}/.env"
+        dest: "{{ react_local_app_path }}/.env"
         mode: 0644
       delegate_to: localhost
       become: true
@@ -12,27 +12,29 @@
 
     - name: Install Javascript requirements locally
       yarn:
-        path: "{{ react_local_checkout_path }}"
+        path: "{{ item }}"
         production: false
       delegate_to: localhost
       become: true
       become_user: "{{ react_local_user }}"
+      loop: "{{react_local_npm_package_paths}}"
 
     - name: Compile Javascript locally
       command: yarn build
       args:
-        chdir: "{{ react_local_checkout_path }}"
+        chdir: "{{ react_local_app_path }}"
       delegate_to: localhost
       become: true
       become_user: "{{ react_local_user }}"
 
     - name: Remove node_modules before compression
       file:
-        path: "{{ react_local_checkout_path }}/node_modules"
+        path: "{{ item }}/node_modules"
         state: absent
       delegate_to: localhost
       become: true
       become_user: "{{ react_local_user }}"
+      loop: "{{react_local_npm_package_paths}}"
 
     - name: Compress Build folder locally
       archive:
@@ -55,15 +57,16 @@
     - name: Copy environment variables file
       template:
         src: env.j2
-        dest: "{{ react_checkout_path }}/.env"
+        dest: "{{ react_app_path }}/.env"
         mode: 0644
 
     - name: Install Javascript requirements
       yarn:
-        path: "{{ react_checkout_path }}"
+        path: "{{ item }}"
         production: false
       become: true
       become_user: "{{ react_system_user }}"
+      loop: "{{react_npm_package_paths}}"
 
     - name: Compile Javascript
       command: yarn build

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -12,17 +12,16 @@
 
     - name: Install Javascript requirements locally
       yarn:
-        path: "{{ item }}"
+        path: "{{ react_local_checkout_path }}"
         production: false
       delegate_to: localhost
       become: true
       become_user: "{{ react_local_user }}"
-      loop: "{{react_local_npm_package_paths}}"
 
     - name: Compile Javascript locally
       command: yarn build
       args:
-        chdir: "{{ react_local_app_path }}"
+        chdir: "{{ react_local_checkout_path }}"
       delegate_to: localhost
       become: true
       become_user: "{{ react_local_user }}"
@@ -40,12 +39,11 @@
 
         - name: remove node_modules manually
           file:
-            path: "{{ item }}/node_modules"
+            path: "{{ react_checkout_path }}/node_modules"
             state: absent
           delegate_to: localhost
           become: true
           become_user: "{{ react_local_user }}"
-          loop: "{{react_local_npm_package_paths}}"
 
     - name: Compress Build folder locally
       archive:
@@ -73,11 +71,10 @@
 
     - name: Install Javascript requirements
       yarn:
-        path: "{{ item }}"
+        path: "{{ react_checkout_path }}"
         production: false
       become: true
       become_user: "{{ react_system_user }}"
-      loop: "{{react_npm_package_paths}}"
 
     - name: Compile Javascript
       command: yarn build


### PR DESCRIPTION
Semantic differentiation between checkout_path and app_path is that the checkout path is the path containing the latest cloned code base, the app_path is the path pointing to a folder within checkout_path where our app package resides.

The need for this arose; since even if we can build the app_path at the checkout_path  we still need to copy env vars to app_path so that they can be effected during build