### PR TITLE
change lerna run build failure indicator

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -80,7 +80,7 @@
       become: true
       become_user: "{{ react_system_user }}"
 
-    - name: Build app locally
+    - name: Build app remotely
       become_user: "{{ react_system_user }}"
       become: true
       environment: "{{ item.env | default(react_build_cmds_default_env) }}"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -27,7 +27,7 @@
       register: yarn_build_result
       args:
         chdir: "{{ item.path | default(react_local_checkout_path) }}"
-      failed_when: "yarn_build_result.stderr is defined and yarn_build_result.stderr.find('error ') != -1"
+      failed_when: "yarn_build_result.stderr is defined and yarn_build_result.stderr.find('Err! ') != -1"
       with_items: "{{ react_build_cmds }}"
 
     - name: Remove node_modules before compression
@@ -88,7 +88,7 @@
       register: yarn_build_result
       args:
         chdir: "{{ item.path | default(react_checkout_path) }}"
-      failed_when: "yarn_build_result.stderr is defined and yarn_build_result.stderr.find('error ') != -1"
+      failed_when: "yarn_build_result.stderr is defined and yarn_build_result.stderr.find('Err! ') != -1"
       with_items: "{{ react_build_cmds }}"
 
   when: "react_remote_js_build|bool"


### PR DESCRIPTION
- The generic `error` matcher matches even non error instances . Eg `error-boundary` 
- rename remote task